### PR TITLE
Betterfied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+index.html
+player_count.html

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib"]
-	path = lib
-	url = https://github.com/DontCamp/frostbite-wire.git

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ optional arguments:
   -d                    show debug info in terminal
   -p PORT, --port PORT  Server port number</pre>
   
-Installation:
+Installation (in a virtualenv with a reasonably recent version of pip):
 * `git clone --recursive https://github.com/robled/bf4-server-status.git`
-* `pip install django pbr`
+* `pip install -Ur requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+django
+pbr
+requests
+-e git+https://github.com/seandst/frostbite-wire.git#egg=frostbite-wire


### PR DESCRIPTION
This addresses a few issues.

First, since it appears bf4-server-status is running in a virtualenv, I gave it a good requirements file. Just do what the readme says in the activeate virtualenv.

Second, I replaced django with jinja2, since jinja2 is a framework-agnostic version of the django templating system, and we were only using django for its templating system. You can see in the Django->Jinja commit that the switch was pretty painless.

Third, I split the playerlist up by teams, and not a silly modulo switcher. This required some tweaking of the `player_data` that gets tossed around, specifically the keys are `Player` objects, not just the player names, since I needed to get at the player's teamId later on.

And finally, I linted stuff and organized the imports so that my editor stops yelling at me about all the badness. It's still pissed about line lengths in the HTML, but I don't care.
